### PR TITLE
chore(deps): actualizar dependencias y cambiar service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Todas las modificaciones importantes de este proyecto se documentarán en este archivo.
 
+## [0.1.0] - 2026-02-02
+### Actualizado
+- Java: 21 → 25
+- Spring Boot: 3.5.8 → 4.0.2
+- Spring Cloud: 2025.0.0 → 2025.1.0
+- SpringDoc OpenAPI: 2.8.10 → 3.0.1
+- Commons Lang3: 3.18.0 → 3.20.0
+- Service Discovery: Eureka → Consul
+
 ## [0.0.1-SNAPSHOT] - 2025-06-19
 ### Agregado
 - Estructura inicial del proyecto Spring Boot 3.5.0

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Este proyecto es el backend para la gestión y consulta del estado de chequeras 
 - **Autenticación**: Endpoint para verificación de cuentas de usuario mediante Google Mail
 - **Gestión de Chequeras**: Consulta del estado de chequeras por persona y facultad
 - **Gestión de Usuarios**: Consulta de usuarios asociados a chequeras por facultad
-- **Arquitectura**: Basada en Spring Boot 3.5.0 con microservicios
-- **Service Discovery**: Integración con Eureka para descubrimiento de servicios
+- **Arquitectura**: Basada en Spring Boot 4.0.2 con microservicios
+- **Service Discovery**: Integración con Consul para descubrimiento de servicios
 - **Rate Limiting**: Protección contra abuso con Resilience4j
 - **Documentación API**: Swagger/OpenAPI integrado
 - **Monitoreo**: Actuator y métricas Prometheus habilitadas
 
 ## Tecnologías utilizadas
-- **Java**: 21
-- **Spring Boot**: 3.5.0
-- **Spring Cloud**: 2025.0.0
+- **Java**: 25
+- **Spring Boot**: 4.0.2
+- **Spring Cloud**: 2025.1.0
 - **Spring Cloud OpenFeign**: Para comunicación entre servicios
-- **Spring Cloud Netflix Eureka**: Service discovery
+- **Spring Cloud Consul**: Service discovery
 - **Resilience4j**: Circuit breaker y rate limiting
 - **Caffeine**: Cache en memoria
 - **Lombok**: Reducción de código boilerplate

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>4.0.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.chequera-proxy</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0</version>
     <name>UM.tesoreria.chequera-proxy</name>
     <description>Tesoreria Chequera Proxy</description>
     <url/>
@@ -28,7 +28,7 @@
     </scm>
     <properties>
         <java.version>25</java.version>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <spring-cloud.version>2025.1.0</spring-cloud.version>
         <sonar.organization>um-services</sonar.organization>
         <sonar.projectKey>UM-services_UM.tesoreria.chequera-proxy</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.10</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
Closes #8

## Descripción
Actualización de dependencias y cambio de Service Discovery en el proyecto de chequera proxy. Se han realizado mejoras significativas en las tecnologías utilizadas para mantener el proyecto al día con las últimas versiones y adoptar Consul como sistema de descubrimiento de servicios.

## Cambios Realizados
- **Java**: Actualizado de 21 a 25
- **Spring Boot**: Actualizado de 3.5.8 a 4.0.2
- **Spring Cloud**: Actualizado de 2025.0.0 a 2025.1.0
- **SpringDoc OpenAPI**: Actualizado de 2.8.10 a 3.0.1
- **Commons Lang3**: Actualizado de 3.18.0 a 3.20.0
- **Service Discovery**: Cambiado de Eureka a Consul
- **Versión del proyecto**: Actualizada de 0.0.1-SNAPSHOT a 0.1.0

## Verificación
- [ ] Compilación exitosa con Maven
- [ ] Tests unitarios pasan
- [ ] Integración con Consul funciona correctamente
- [ ] Documentación actualizada
